### PR TITLE
Fix the no brushes, patterns and palettes issue

### DIFF
--- a/com.orama_interactive.Pixelorama.yaml
+++ b/com.orama_interactive.Pixelorama.yaml
@@ -47,7 +47,7 @@ modules:
     build-commands:
       - install -Dm755 pixelorama.sh /app/bin/pixelorama
       - install -Dm644 Pixelorama.pck /app/bin/pixelorama.pck
-      - mv pixelorama_data/{Brushes,Palettes,Patterns}/ /app/bin/
+      - mv pixelorama_data/ /app/bin/
       - install -Dm644 icon.png -t /app/share/icons/hicolor/256x256/apps/
       - install -Dm644 com.orama_interactive.Pixelorama.desktop -t /app/share/applications/
       - install -Dm644 com.orama_interactive.Pixelorama.appdata.xml -t /app/share/appdata/


### PR DESCRIPTION
The issue seems to be that the child directories of pixelorama_data (the Brushes, Palettes and Patterns directories) are being moved to /app/bin/, instead of the pixelorama_data directory itself.

Fixes https://github.com/Orama-Interactive/Pixelorama/issues/248