### PR TITLE
Update to FreeDesktop 22.08 runtime

### DIFF
--- a/com.orama_interactive.Pixelorama.yaml
+++ b/com.orama_interactive.Pixelorama.yaml
@@ -2,7 +2,7 @@ app-id: com.orama_interactive.Pixelorama
 base: org.godotengine.godot.BaseApp
 base-version: '3.5'
 runtime: org.freedesktop.Platform
-runtime-version: "21.08"
+runtime-version: "22.08"
 default-branch: stable
 sdk: org.freedesktop.Sdk
 command: pixelorama


### PR DESCRIPTION
21.08 runtime will be end-of-life in a few months from now.