### PR TITLE
Update to v1.1

### DIFF
--- a/com.orama_interactive.Pixelorama.yaml
+++ b/com.orama_interactive.Pixelorama.yaml
@@ -1,6 +1,6 @@
 app-id: com.orama_interactive.Pixelorama
 base: org.godotengine.godot.BaseApp
-base-version: '4.3-24.08'
+base-version: '4.4'
 runtime: org.freedesktop.Platform
 runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
@@ -12,6 +12,7 @@ finish-args:
   - --socket=x11
   - --filesystem=home
   - --device=dri
+  - --socket=pulseaudio
 
 modules:
   - name: pixelorama
@@ -19,8 +20,8 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/Orama-Interactive/Pixelorama/releases/download/v1.0.5/Pixelorama-Linux-64bit.tar.gz
-        sha256: f0c8d72129f34997d23eb2c466f59dd453b9f33cba2ac463fdb99d506850c407
+        url: https://github.com/Orama-Interactive/Pixelorama/releases/download/v1.1/Pixelorama-Linux-64bit.tar.gz
+        sha256: 9fd279ef5578b573d9cc4f9338dfdad2489d6d25f81099acbb2cf562dfb07e59
         strip-components: 1
 
       - type: script
@@ -28,25 +29,25 @@ modules:
         commands:
           # `cd` is needed so that Pixelorama can find the `Brushes/` directory
           - cd /app/bin/
-          # Use the `Dummy` audio driver to avoid error messages when starting the application from a terminal
-          - /app/bin/godot-runner --audio-driver Dummy --main-pack /app/bin/pixelorama.pck "$@"
+          # Needed so Pixelorama can run
+          - /app/bin/godot-runner --main-pack /app/bin/pixelorama.pck "$@"
 
       - type: file
-        url: https://raw.githubusercontent.com/Orama-Interactive/Pixelorama/v1.0.5/assets/graphics/icons/icon.png
+        url: https://raw.githubusercontent.com/Orama-Interactive/Pixelorama/v1.1/assets/graphics/icons/icon.png
         sha256: 184a59fbb665f1b9e8b2bc0d8e969903c1554cf9cbc729d68d02e846682e6419
 
       - type: file
-        url: https://raw.githubusercontent.com/Orama-Interactive/Pixelorama/v1.0.5/Misc/Linux/com.orama_interactive.Pixelorama.desktop
-        sha256: f55e641204bd30f9343bb3e42ab180522ae2ffdcd60b1b65f84e18dacc6a99f1
+        url: https://raw.githubusercontent.com/Orama-Interactive/Pixelorama/v1.1/Misc/Linux/com.orama_interactive.Pixelorama.desktop
+        sha256: 357d058e56a4286dea412ed4694a9b95336405387a3fee3ad9f10019de9dc753
 
       - type: file
-        url: https://raw.githubusercontent.com/Orama-Interactive/Pixelorama/v1.0.5/Misc/Linux/com.orama_interactive.Pixelorama.appdata.xml
-        sha256: b448f7ba8e035596356698e334a8819a49374a04018e2c3bb08f65ed6e99aed7
+        url: https://raw.githubusercontent.com/Orama-Interactive/Pixelorama/v1.1/Misc/Linux/com.orama_interactive.Pixelorama.appdata.xml
+        sha256: 8c7555e4394b3c62a5f5122baa9720aee30b7a204ff10794dfdb7d5c12c2e1f5
       - type: patch
         path: pixelorama-appdata.patch
 
       - type: file
-        url: https://raw.githubusercontent.com/Orama-Interactive/Pixelorama/v1.0.5/Misc/Linux/com.orama_interactive.Pixelorama.xml
+        url: https://raw.githubusercontent.com/Orama-Interactive/Pixelorama/v1.1/Misc/Linux/com.orama_interactive.Pixelorama.xml
         sha256: 4fcf324e7c1eb8277bd9368047c0f9368ff1a32d3aba14d6b7d6459efcf7054f
 
     build-commands:


### PR DESCRIPTION
https://github.com/Orama-Interactive/Pixelorama/releases/tag/v1.1

Since v1.1 is introducing audio layers, I removed the Dummy audio driver command. I will test it before merging in case there are any errors due to this change.

EDIT: Completely removing the line results in Pixelorama not running, so I just removed the `--audio-driver Dummy` part and I also added `--socket=pulseaudio` in the permissions.